### PR TITLE
Change order of decorators in example

### DIFF
--- a/examples/fastapi-example.py
+++ b/examples/fastapi-example.py
@@ -14,8 +14,8 @@ def metrics():
 
 
 # Set up the root endpoint of the API
-@app.get("/")
 @autometrics
+@app.get("/")
 def read_root():
     do_something()
     return {"Hello": "World"}


### PR DESCRIPTION
It is better if the autometrics decorator is the top decorator so the actual caller function gets stored instead of information on the decorator