### PR TITLE
Add link to Grafana dashboards in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ See [Why Autometrics?](https://github.com/autometrics-dev#why-autometrics) for m
 - 🔗 Create links to live Prometheus charts directly into each functions docstrings (with tooltips coming soon!)
 - [🚨 Define alerts](#alerts--slos) using SLO best practices directly in your source code
 - [📊 Grafana dashboards](#dashboards) work out of the box to visualize the performance of instrumented functions & SLOs
-- [⚙️ Configurable](#metrics-libraries) metric collection library (`opentelemetry`, `prometheus`, or `metrics`)- ⚡ Minimal runtime overhead
+- [⚙️ Configurable](#metrics-libraries) metric collection library (`opentelemetry`, `prometheus`, or `metrics`)
+- ⚡ Minimal runtime overhead
 
 ## Using autometrics-py
 


### PR DESCRIPTION
Simple PR. The README stated that Grafana Dashboards were "Coming soon", but in fact we have a shared repo with the JSON you need to set them up.