### PR TITLE
Add support for decorating async functions

### DIFF
--- a/examples/django_example/django_example/asgi.py
+++ b/examples/django_example/django_example/asgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'django_example.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "django_example.settings")
 
 application = get_asgi_application()

--- a/examples/django_example/django_example/wsgi.py
+++ b/examples/django_example/django_example/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'django_example.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "django_example.settings")
 
 application = get_wsgi_application()

--- a/examples/django_example/manage.py
+++ b/examples/django_example/manage.py
@@ -6,7 +6,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'django_example.settings')
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "django_example.settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:
@@ -18,5 +18,5 @@ def main():
     execute_from_command_line(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/examples/example.py
+++ b/examples/example.py
@@ -94,6 +94,6 @@ while True:
 
     try:
         # Call random_error. It will randomly raise an error or return "ok"
-        random_error() 
+        random_error()
     except Exception:
         pass

--- a/examples/fastapi-example.py
+++ b/examples/fastapi-example.py
@@ -7,7 +7,7 @@ app = FastAPI()
 
 
 # Set up a metrics endpoint for Prometheus to scrape
-# `generate_lates` returns the latest metrics data in the Prometheus text format
+# `generate_latest` returns the latest metrics data in the Prometheus text format
 @app.get("/metrics")
 def metrics():
     return Response(generate_latest())

--- a/examples/fastapi-example.py
+++ b/examples/fastapi-example.py
@@ -15,16 +15,16 @@ def metrics():
 
 
 # Set up the root endpoint of the API
-@autometrics
 @app.get("/")
+@autometrics
 def read_root():
     do_something()
     return {"Hello": "World"}
 
 
 # Set up an async handler
-@autometrics
 @app.get("/async")
+@autometrics
 async def async_route():
     message = await do_something_async()
     return {"Hello": message}

--- a/examples/fastapi-example.py
+++ b/examples/fastapi-example.py
@@ -1,3 +1,4 @@
+import asyncio
 from fastapi import FastAPI, Response
 import uvicorn
 from autometrics import autometrics
@@ -21,9 +22,25 @@ def read_root():
     return {"Hello": "World"}
 
 
+# Set up an async handler
+@autometrics
+@app.get("/async")
+async def async_route():
+    message = await do_something_async()
+    return {"Hello": message}
+
+
 @autometrics
 def do_something():
     print("done")
+
+
+@autometrics
+async def do_something_async():
+    print("async start")
+    await asyncio.sleep(2.0)
+    print("async done")
+    return "async world"
 
 
 if __name__ == "__main__":

--- a/poetry.lock
+++ b/poetry.lock
@@ -989,6 +989,25 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.21.0"
+description = "Pytest support for asyncio"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-asyncio-0.21.0.tar.gz", hash = "sha256:2b38a496aef56f56b0e87557ec313e11e1ab9276fc3863f6a7be0f1d0e415e1b"},
+    {file = "pytest_asyncio-0.21.0-py3-none-any.whl", hash = "sha256:f2b3366b7cd501a4056858bd39349d5af19742aed2d81660b7998b6341c7eb9c"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
+
+[[package]]
 name = "python-dotenv"
 version = "1.0.0"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -1411,4 +1430,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "2c1a48e550706a58b930ae2acc50a5bd03a29bef34251cb72f2bdcfc0794efe3"
+content-hash = "ffab8d31818912728e687168957e18888fe71d72ea6493a38c87ecbc6f5a6258"

--- a/poetry.lock
+++ b/poetry.lock
@@ -421,14 +421,14 @@ dev = ["PyTest", "PyTest (<5)", "PyTest-Cov", "PyTest-Cov (<2.6)", "bump2version
 
 [[package]]
 name = "django"
-version = "4.2"
+version = "4.2.1"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "Django-4.2-py3-none-any.whl", hash = "sha256:ad33ed68db9398f5dfb33282704925bce044bef4261cd4fb59e4e7f9ae505a78"},
-    {file = "Django-4.2.tar.gz", hash = "sha256:c36e2ab12824e2ac36afa8b2515a70c53c7742f0d6eaefa7311ec379558db997"},
+    {file = "Django-4.2.1-py3-none-any.whl", hash = "sha256:066b6debb5ac335458d2a713ed995570536c8b59a580005acb0732378d5eb1ee"},
+    {file = "Django-4.2.1.tar.gz", hash = "sha256:7efa6b1f781a6119a10ac94b4794ded90db8accbe7802281cd26f8664ffed59c"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ optional = true
 [tool.poetry.group.dev.dependencies]
 pyright = "^1.1.302"
 pytest = "^7.3.0"
+pytest-asyncio = "^0.21.0"
 black = "^23.3.0"
 
 [tool.poetry.group.examples]

--- a/src/autometrics/decorator.py
+++ b/src/autometrics/decorator.py
@@ -38,7 +38,6 @@ def autometrics(
     objective: Optional[Objective] = None,
 ):
     def track_result_ok(start_time: float, function: str, module: str, caller: str):
-        print("THE CALLER:", caller)
         get_tracker().finish(
             start_time,
             function=function,

--- a/src/autometrics/decorator.py
+++ b/src/autometrics/decorator.py
@@ -4,7 +4,7 @@ import inspect
 
 # import asyncio
 from functools import wraps
-from typing import overload, TypeVar, Callable, Optional
+from typing import overload, TypeVar, Callable, Optional, Coroutine, Any
 from typing_extensions import ParamSpec
 from .objectives import Objective
 from .tracker import get_tracker, Result
@@ -66,7 +66,9 @@ def autometrics(
         module_name = get_module_name(func)
         func_name = func.__name__
 
-        def sync_wrapper_helper(func, *args, **kwds) -> T:
+        def sync_wrapper_helper(
+            func: Callable[P, T], *args: P.args, **kwds: P.kwargs
+        ) -> T:
             start_time = time.time()
             caller = get_caller_function()
 
@@ -89,7 +91,9 @@ def autometrics(
                 raise exception
             return result
 
-        async def async_wrapper_helper(func, *args, **kwds) -> T:
+        async def async_wrapper_helper(
+            func: Callable[P, T], *args: P.args, **kwds: P.kwargs
+        ) -> T:
             start_time = time.time()
             caller = get_caller_function()
 

--- a/src/autometrics/decorator.py
+++ b/src/autometrics/decorator.py
@@ -1,5 +1,9 @@
 """Autometrics module."""
 import time
+import inspect
+import asyncio
+
+# import asyncio
 from functools import wraps
 from typing import overload, TypeVar, Callable, Optional
 from typing_extensions import ParamSpec
@@ -71,7 +75,52 @@ def autometrics(
             wrapper.__doc__ = f"{func.__doc__}\n{write_docs(func_name, module_name)}"
         return wrapper
 
+    """Decorator for tracking async function calls and duration."""
+
+    def async_decorator(func: Callable[P, T]) -> Callable[P, T]:
+        module_name = get_module_name(func)
+        func_name = func.__name__
+
+        @wraps(func)
+        async def wrapper(*args: P.args, **kwds: P.kwargs) -> T:
+            start_time = time.time()
+            caller = get_caller_function()
+
+            try:
+                result = await func(*args, **kwds)
+                get_tracker().finish(
+                    start_time,
+                    function=func_name,
+                    module=module_name,
+                    caller=caller,
+                    objective=objective,
+                    result=Result.OK,
+                )
+
+            except Exception as exception:
+                result = exception.__class__.__name__
+                get_tracker().finish(
+                    start_time,
+                    function=func_name,
+                    module=module_name,
+                    caller=caller,
+                    objective=objective,
+                    result=Result.ERROR,
+                )
+                # Reraise exception
+                raise exception
+            return result
+
+        if func.__doc__ is None:
+            wrapper.__doc__ = write_docs(func_name, module_name)
+        else:
+            wrapper.__doc__ = f"{func.__doc__}\n{write_docs(func_name, module_name)}"
+        return wrapper
+
     if func is None:
         return decorator
+    elif inspect.iscoroutinefunction(func):
+        print("Using async_decorator")
+        return async_decorator(func)
     else:
         return decorator(func)

--- a/src/autometrics/decorator.py
+++ b/src/autometrics/decorator.py
@@ -63,7 +63,6 @@ def autometrics(
             result=Result.ERROR,
         )
 
-
     def sync_decorator(func: Callable[P, T]) -> Callable[P, T]:
         """Helper for decorating synchronous functions, to track calls and duration."""
 
@@ -95,7 +94,6 @@ def autometrics(
 
         sync_wrapper.__doc__ = append_docs_to_docstring(func, func_name, module_name)
         return sync_wrapper
-
 
     def async_decorator(func: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
         """Helper for decorating async functions, to track calls and duration."""

--- a/src/autometrics/decorator.py
+++ b/src/autometrics/decorator.py
@@ -2,7 +2,6 @@
 import time
 import inspect
 
-# import asyncio
 from functools import wraps
 from typing import overload, TypeVar, Callable, Optional, Awaitable
 from typing_extensions import ParamSpec

--- a/src/autometrics/decorator.py
+++ b/src/autometrics/decorator.py
@@ -1,7 +1,6 @@
 """Autometrics module."""
 import time
 import inspect
-import asyncio
 
 # import asyncio
 from functools import wraps

--- a/src/autometrics/test_decorator.py
+++ b/src/autometrics/test_decorator.py
@@ -28,6 +28,12 @@ async def basic_async_function(sleep_duration: float = 1.0):
     return True
 
 
+async def error_async_function():
+    """This is an async function that raises an error."""
+    await asyncio.sleep(0.5)
+    raise RuntimeError("This is a test error")
+
+
 tracker_types = [TrackerType.PROMETHEUS, TrackerType.OPENTELEMETRY]
 
 
@@ -153,6 +159,41 @@ class TestDecoratorClass:
 
         with pytest.raises(RuntimeError) as exception:
             wrapped_function()
+        assert "This is a test error" in str(exception.value)
+
+        # get the metrics
+        blob = generate_latest()
+        assert blob is not None
+        data = blob.decode("utf-8")
+
+        total_count = f"""function_calls_count_total{{caller="{caller}",function="{function_name}",module="test_decorator",objective_name="",objective_percentile="",result="error"}} 1.0"""
+        assert total_count in data
+
+        for latency in ObjectiveLatency:
+            query = f"""function_calls_duration_bucket{{function="{function_name}",le="{latency.value}",module="test_decorator",objective_latency_threshold="",objective_name="",objective_percentile=""}}"""
+            assert query in data
+
+        duration_count = f"""function_calls_duration_count{{function="{function_name}",module="test_decorator",objective_latency_threshold="",objective_name="",objective_percentile=""}}"""
+        assert duration_count in data
+
+        duration_sum = f"""function_calls_duration_sum{{function="{function_name}",module="test_decorator",objective_latency_threshold="",objective_name="",objective_percentile=""}}"""
+        assert duration_sum in data
+
+    @pytest.mark.asyncio
+    async def test_async_exception(self):
+        """This is a test that covers exceptions."""
+        caller = get_caller_function(depth=1)
+        assert caller is not None
+        assert caller != ""
+
+        function_name = error_async_function.__name__
+        wrapped_function = autometrics(error_async_function)
+
+        # Test that the function is *still* async after we wrap it
+        assert asyncio.iscoroutinefunction(wrapped_function) == True
+
+        with pytest.raises(RuntimeError) as exception:
+            await wrapped_function()
         assert "This is a test error" in str(exception.value)
 
         # get the metrics

--- a/src/autometrics/test_decorator.py
+++ b/src/autometrics/test_decorator.py
@@ -50,7 +50,6 @@ class TestDecoratorClass:
         assert caller != ""
         function_name = basic_function.__name__
         wrapped_function = autometrics(basic_function)
-
         wrapped_function()
 
         blob = generate_latest()
@@ -84,7 +83,6 @@ class TestDecoratorClass:
         # Test that the function is *still* async after we wrap it
         assert asyncio.iscoroutinefunction(wrapped_function) == True
 
-        # NOTE - This runs the function synchronously, but it's still an async function
         await wrapped_function()
 
         blob = generate_latest()

--- a/src/autometrics/test_decorator.py
+++ b/src/autometrics/test_decorator.py
@@ -21,10 +21,12 @@ def error_function():
     """This is a function that raises an error."""
     raise RuntimeError("This is a test error")
 
+
 async def basic_async_function(sleep_duration: float = 1.0):
     """This is a basic async function."""
     await asyncio.sleep(sleep_duration)
     return True
+
 
 tracker_types = [TrackerType.PROMETHEUS, TrackerType.OPENTELEMETRY]
 
@@ -78,7 +80,7 @@ class TestDecoratorClass:
         assert caller != ""
         function_name = basic_async_function.__name__
         wrapped_function = autometrics(basic_async_function)
-        
+
         # Test that the function is *still* async after we wrap it
         assert asyncio.iscoroutinefunction(wrapped_function) == True
 

--- a/src/autometrics/utils.py
+++ b/src/autometrics/utils.py
@@ -40,6 +40,14 @@ def write_docs(func_name: str, module_name: str):
     return docs
 
 
+def append_docs_to_docstring(func, func_name, module_name):
+    """Helper for appending docs to a function's docstring."""
+    if func.__doc__ is None:
+        return write_docs(func_name, module_name)
+    else:
+        return f"{func.__doc__}\n{write_docs(func_name, module_name)}"
+
+
 def get_caller_function(depth: int = 2):
     """Get the name of the function. Default depth is 2 to get the caller of the caller of the function being decorated."""
     caller_frame = inspect.stack()[depth]


### PR DESCRIPTION
This PR adds support for async functions, making the following changes:

- Conditionally return a sync or async wrapped function, depending on whether the decorated function returns true from `iscoroutinefunction` 
- Write an additional overload for the `autometrics` decorator, using `Callable[P, Awaitable[T]]` as part of the type signature
- Factor out shared logic from `decorator` and `async_decorator`
- Add a test of a simple async function in `test_decorator.py` (which required adding the `pytest-asyncio` module to dev dependencies)
- Add async code to the `fastapi-example.py` example

***

Fixes #29 