### PR TITLE
Make SLO examples in README clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,19 @@ To use autometrics SLOs and alerts, create one or multiple `Objective`s based on
 from autometrics import autometrics
 from autometrics.objectives import Objective, ObjectiveLatency, ObjectivePercentile
 
-API_SLO = Objective(
-    "My API SLO for High Error Rate",
+# Create an objective for a high success rate
+API_SLO_HIGH_SUCCESS = Objective(
+    "My API SLO for High Success Rate (99.9%)",
     success_rate=ObjectivePercentile.P99_9,
+)
+
+# Or you can also create an objective for low latency
+API_SLO_LOW_LATENCY = Objective(
+    "My API SLO for Low Latency (99th percentile < 250ms)",
     latency=(ObjectiveLatency.Ms250, ObjectivePercentile.P99),
 )
 
-@autometrics(objective=API_SLO)
+@autometrics(objective=API_SLO_HIGH_SUCCESS)
 def api_handler():
   # ...
 ```


### PR DESCRIPTION
This came out of a conversation with Ivan, where I asked him why our example code contained both latency and success_rate. Although that's possible, it'd be more common to simply define one or the other. This way, the examples can also make it clearer what specifically they're doing.