### PR TITLE
Improve caller detection

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 ---
-name: Lint
+name: Lint and test
 
 on:
   pull_request:
@@ -8,15 +8,18 @@ on:
     branches: ["main"]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.11", "pypy3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Install poetry
         run: pipx install poetry
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
           cache: "poetry"
       - name: Install dependencies
         run: poetry install --no-interaction --no-root --with dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
--
+- Caller tracking only tracks autometricised functions, as per spec #59
+- Function name labels now use qualified name, and module labels use module's `__name__` when available #59
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![GitHub_headerImage](https://user-images.githubusercontent.com/3262610/221191767-73b8a8d9-9f8b-440e-8ab6-75cb3c82f2bc.png)
 
+[![Tests](https://github.com/autometrics-dev/autometrics-py/actions/workflows/main.yml/badge.svg)](https://github.com/autometrics-dev/autometrics-py/actions/workflows/main.yml)
 [![Discord Shield](https://discordapp.com/api/guilds/950489382626951178/widget.png?style=shield)](https://discord.gg/kHtwcH8As9)
 
 > A Python port of the Rust
@@ -24,7 +25,7 @@ See [Why Autometrics?](https://github.com/autometrics-dev#why-autometrics) for m
 - [🔍 Identify commits](#identifying-commits-that-introduced-problems) that introduced errors or increased latency
 - [🚨 Define alerts](#alerts--slos) using SLO best practices directly in your source code
 - [📊 Grafana dashboards](#dashboards) work out of the box to visualize the performance of instrumented functions & SLOs
-- [⚙️ Configurable](#metrics-libraries) metric collection library (`opentelemetry`, `prometheus`, or `metrics`)
+- [⚙️ Configurable](#metrics-libraries) metric collection library (`opentelemetry` or `prometheus`)
 - [📍 Attach exemplars](#exemplars) to connect metrics with traces
 - ⚡ Minimal runtime overhead
 
@@ -86,39 +87,7 @@ def api_handler():
   # ...
 ```
 
-Autometrics by default will try to store information on which function calls a decorated function. As such you may want to place the autometrics in the top/first decorator, as otherwise you may get `inner` or `wrapper` as the caller function.
-
-So instead of writing:
-
-```py
-from functools import wraps
-from typing import Any, TypeVar, Callable
-
-R = TypeVar("R")
-
-def noop(func: Callable[..., R]) -> Callable[..., R]:
-    """A noop decorator that does nothing."""
-
-    @wraps(func)
-    def inner(*args: Any, **kwargs: Any) -> Any:
-        return func(*args, **kwargs)
-
-    return inner
-
-@noop
-@autometrics
-def api_handler():
-  # ...
-```
-
-You may want to switch the order of the decorator
-
-```py
-@autometrics
-@noop
-def api_handler():
-  # ...
-```
+Autometrics keeps track of instrumented functions calling each other. If you have a function that calls another function, metrics for later will include `caller` label set to the name of the autometricised function that called it.
 
 #### Metrics Libraries
 

--- a/src/autometrics/test_caller.py
+++ b/src/autometrics/test_caller.py
@@ -1,0 +1,43 @@
+"""Tests for caller tracking."""
+from functools import wraps
+from prometheus_client.exposition import generate_latest
+
+from .decorator import autometrics
+
+
+def test_caller_detection():
+    """This is a test to see if the caller is properly detected."""
+
+    def dummy_decorator(func):
+        @wraps(func)
+        def dummy_wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        return dummy_wrapper
+
+    def another_decorator(func):
+        @wraps(func)
+        def another_wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        return another_wrapper
+
+    @dummy_decorator
+    @autometrics
+    @another_decorator
+    def foo():
+        pass
+
+    @autometrics
+    def bar():
+        foo()
+
+    bar()
+
+    blob = generate_latest()
+    assert blob is not None
+    data = blob.decode("utf-8")
+
+    expected = """function_calls_count_total{caller="test_caller_detection.<locals>.bar",function="test_caller_detection.<locals>.foo",module="autometrics.test_caller",objective_name="",objective_percentile="",result="ok"} 1.0"""
+    assert "wrapper" not in data
+    assert expected in data

--- a/src/autometrics/tracker/test_concurrency.py
+++ b/src/autometrics/tracker/test_concurrency.py
@@ -6,6 +6,7 @@ import pytest
 from .tracker import set_tracker, TrackerType
 
 from ..decorator import autometrics
+from ..utils import get_function_name, get_module_name
 
 
 @autometrics(track_concurrency=True)
@@ -19,6 +20,9 @@ async def test_concurrency_tracking_prometheus(monkeypatch):
     #        because the library was already initialized with the OpenTelemetry tracker
     set_tracker(TrackerType.PROMETHEUS)
 
+    func_name = get_function_name(sleep)
+    module_name = get_module_name(sleep)
+
     # Create a 200ms async task
     loop = asyncio.get_event_loop()
     task = loop.create_task(sleep(0.2))
@@ -31,9 +35,9 @@ async def test_concurrency_tracking_prometheus(monkeypatch):
     await task
     assert blob is not None
     data = blob.decode("utf-8")
-    print(data)
+
     assert (
-        f"""# TYPE function_calls_concurrent gauge\nfunction_calls_concurrent{{function="sleep",module="test_concurrency"}} 1.0"""
+        f"""# TYPE function_calls_concurrent gauge\nfunction_calls_concurrent{{function="sleep",module="autometrics.tracker.test_concurrency"}} 1.0"""
         in data
     )
 

--- a/src/autometrics/utils.py
+++ b/src/autometrics/utils.py
@@ -1,19 +1,16 @@
 import inspect
 import os
 from collections.abc import Callable
+
 from .prometheus_url import Generator
 
 
 def get_module_name(func: Callable) -> str:
     """Get the name of the module that contains the function."""
-    func_name = func.__name__
-    fullname = func.__qualname__
-    filename = get_filename_as_module(func)
-    if fullname == func_name:
-        return filename
-
-    classname = func.__qualname__.rsplit(".", 1)[0]
-    return f"{filename}.{classname}"
+    module = inspect.getmodule(func)
+    if module is None:
+        return get_filename_as_module(func)
+    return module.__name__
 
 
 def get_filename_as_module(func: Callable) -> str:
@@ -25,6 +22,11 @@ def get_filename_as_module(func: Callable) -> str:
     filename = os.path.basename(fullpath)
     module_part = os.path.splitext(filename)[0]
     return module_part
+
+
+def get_function_name(func: Callable) -> str:
+    """Get the name of the function."""
+    return func.__qualname__ or func.__name__
 
 
 def write_docs(func_name: str, module_name: str):
@@ -46,10 +48,3 @@ def append_docs_to_docstring(func, func_name, module_name):
         return write_docs(func_name, module_name)
     else:
         return f"{func.__doc__}\n{write_docs(func_name, module_name)}"
-
-
-def get_caller_function(depth: int = 2):
-    """Get the name of the function. Default depth is 2 to get the caller of the caller of the function being decorated."""
-    caller_frame = inspect.stack()[depth]
-    caller_function_name = caller_frame[3]
-    return caller_function_name


### PR DESCRIPTION
- Change decorator behavior to keep track of caller according to spec
- Switch to qualified names for functions to uniquely point to a function in file
- Use module's `__name__` for label which uses package names instead of just fs path
- Linting now runs both python 3.11, 3.7 and even latest pypy