### PR TITLE
Fix opentelemetry tracker duration recorded values

### DIFF
--- a/src/autometrics/tracker/opentelemetry.py
+++ b/src/autometrics/tracker/opentelemetry.py
@@ -123,7 +123,7 @@ class OpenTelemetryTracker:
             percentile = latency[1].value
 
         self.__histogram_instance.record(
-            duration * 1000,
+            duration,
             attributes={
                 "function": function,
                 "module": module,


### PR DESCRIPTION
The OpenTelemetry tracker assumed it was seeing duration in MS, so it was multiplying all durations by 1000.

This PR is a one-liner to fix that. 