### PR TITLE
Add quickstart to README and spruce up a few sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 > A Python port of the Rust
 > [autometrics-rs](https://github.com/fiberplane/autometrics-rs) library
 
-**Autometrics is a library that exports a decorator that makes it easy to understand the error rate, response time, and production usage of any function in your code.** Jump straight from your IDE to live Prometheus charts for each HTTP/RPC handler, database method, or other piece of application logic.
+**Autometrics is a library that makes it easy to understand the error rate, response time, and production usage of any function in your code.** Jump straight from your IDE to live Prometheus charts for each HTTP/RPC handler, database method, or other piece of application logic.
 
 Autometrics for Python provides:
 
@@ -17,7 +17,7 @@ See [Why Autometrics?](https://github.com/autometrics-dev#why-autometrics) for m
 
 ## Features
 
-- ✨ `autometrics` decorator instruments any function or class method to track the
+- ✨ `@autometrics` decorator instruments any function or class method to track the
   most useful metrics
 - 💡 Writes Prometheus queries so you can understand the data generated without
   knowing PromQL
@@ -76,13 +76,15 @@ See [Why Autometrics?](https://github.com/autometrics-dev#why-autometrics) for m
 
     ```
 
-- You can also track the number of concurrent calls to a function by using the `track_concurrency` argument: `@autometrics(track_concurrency=True)`. Note: this currently only supported by the `prometheus` tracker, set with the environment variable `AUTOMETRICS_TRACKER=prometheus`.
+- You can also track the number of concurrent calls to a function by using the `track_concurrency` argument: `@autometrics(track_concurrency=True)`. 
+
+    > Note: Concurrency tracking is only supported when you set with the environment variable `AUTOMETRICS_TRACKER=prometheus`.
 
 - To access the PromQL queries for your decorated functions, run `help(yourfunction)` or `print(yourfunction.__doc__)`.
 
 - To show tooltips over decorated functions in VSCode, with links to Prometheus queries, try installing [the VSCode extension](https://marketplace.visualstudio.com/items?itemName=Fiberplane.autometrics).
 
-> Note that we cannot support tooltips without a VSCode extension due to behavior of the [static analyzer](https://github.com/davidhalter/jedi/issues/1921) used in VSCode.
+    > Note that we cannot support tooltips without a VSCode extension due to behavior of the [static analyzer](https://github.com/davidhalter/jedi/issues/1921) used in VSCode.
 
 ## Dashboards
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,22 @@ Autometrics makes use of a number of environment variables to configure its beha
 - `service_name` - Configure the [service name](#service-name).
 - `version`, `commit`, `branch` - Used to configure [build_info](#build-info).
 
+Below is an example of initializing autometrics with build_info, as well as the `prometheus` tracker. (Note that you can also do this with environment variables.)
+
+```python
+from autometrics import autometrics, init
+from git_utils import get_git_commit, get_git_branch
+
+VERSION = "0.0.1"
+
+init(
+  tracker="prometheus",
+  version=VERSION,
+  commit=get_git_commit(),
+  branch=get_git_branch()
+)
+```
+
 ## Identifying commits that introduced problems <span name="build-info" />
 
 Autometrics makes it easy to identify if a specific version or commit introduced errors or increased latencies.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ This allows you to drill down into the metrics for functions that are _called by
 
 In the example above, this means that you could investigate the latency of the database queries that `get_users` makes, which is rather useful.
 
-## Settings
+## Settings and Configuration
 
 Autometrics makes use of a number of environment variables to configure its behavior. All of them are also configurable with keyword arguments to the `init` function.
 
@@ -168,17 +168,20 @@ Autometrics makes use of a number of environment variables to configure its beha
 
 ## Identifying commits that introduced problems <span name="build-info" />
 
-> **NOTE** - As of writing, `build_info` will not work correctly when using the default tracker (`AUTOMETRICS_TRACKER=opentelemetry`).
-> If you wish to use `build_info`, you must use the `prometheus` tracker instead (`AUTOMETRICS_TRACKER=prometheus`).
->
-> This issue will be fixed once the following PR is merged and released on the opentelemetry-python project: https://github.com/open-telemetry/opentelemetry-python/pull/3306
->
-> autometrics-py will track support for build_info using the OpenTelemetry tracker via #38
-
 Autometrics makes it easy to identify if a specific version or commit introduced errors or increased latencies.
 
-It uses a separate metric (`build_info`) to track the version and, optionally, git commit of your service. It then writes queries that group metrics by the `version`, `commit` and `branch` labels so you can spot correlations between those and potential issues.
-Configure the labels by setting the following environment variables:
+> **NOTE** - As of writing, `build_info` will not work correctly when using the default setting of `AUTOMETRICS_TRACKER=opentelemetry`. If you wish to use `build_info`, you must use the `prometheus` tracker instead (`AUTOMETRICS_TRACKER=prometheus`).
+>
+> The issue will be fixed once the following PR is merged and released on the opentelemetry-python project: https://github.com/open-telemetry/opentelemetry-python/pull/3306
+>
+> autometrics-py will track support for build_info using the OpenTelemetry tracker via [this issue](https://github.com/autometrics-dev/autometrics-py/issues/38)
+
+
+The library uses a separate metric (`build_info`) to track the version and, optionally, the git commit of your service. 
+
+It then writes queries that group metrics by the `version`, `commit` and `branch` labels so you can spot correlations between code changes and potential issues.
+
+Configure these labels by setting the following environment variables:
 
 | Label     | Run-Time Environment Variables        | Default value |
 | --------- | ------------------------------------- | ------------- |

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ See [Why Autometrics?](https://github.com/autometrics-dev#why-autometrics) for m
 
 - To access the PromQL queries for your decorated functions, run `help(yourfunction)` or `print(yourfunction.__doc__)`.
 
+    > For these queries to work, include a `.env` file in your project with your prometheus endpoint `PROMETHEUS_URL=your endpoint`. If this is not defined, the default endpoint will be `http://localhost:9090/`
+
 ## Dashboards
 
 Autometrics provides [Grafana dashboards](https://github.com/autometrics-dev/autometrics-shared#dashboards) that will work for any project instrumented with the library.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ See [Why Autometrics?](https://github.com/autometrics-dev#why-autometrics) for m
 
 4. Run Prometheus locally with the [Autometrics CLI](https://docs.autometrics.dev/local-development#getting-started-with-am) or [configure it manually](https://github.com/autometrics-dev#5-configuring-prometheus) to scrape your metrics endpoint
     ```sh
-    am start :8080 # or whichever port your app runs on
+    am start :8080 # Replace `8080` with the port that your app runs on
     ```
   
 5. (Optional) If you have Grafana, import the [Autometrics dashboards](https://github.com/autometrics-dev/autometrics-shared#dashboards) for an overview and detailed view of all the function metrics you've collected

--- a/README.md
+++ b/README.md
@@ -6,12 +6,9 @@
 > A Python port of the Rust
 > [autometrics-rs](https://github.com/fiberplane/autometrics-rs) library
 
-**Autometrics is a library that makes it easy to understand the error rate, response time, and production usage of any function in your code.** Jump straight from your IDE to live Prometheus charts for each HTTP/RPC handler, database method, or other piece of application logic.
+Metrics are a powerful and cost-efficient tool for understanding the health and performance of your code in production. But it's hard to decide what metrics to track and even harder to write queries to understand the data.
 
-Autometrics for Python provides:
-
-1. A decorator that can create [Prometheus](https://prometheus.io/) metrics for your functions and class methods throughout your code base.
-2. A helper function that will write corresponding Prometheus queries for you in a Markdown file.
+Autometrics provides a decorator that makes it trivial to instrument any function with the most useful metrics: request rate, error rate, and latency. It standardizes these metrics and then generates powerful Prometheus queries based on your function details to help you quickly identify and debug issues in production.
 
 See [Why Autometrics?](https://github.com/autometrics-dev#why-autometrics) for more details on the ideas behind autometrics.
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Autometrics makes use of a number of environment variables to configure its beha
 - `service_name` - Configure the [service name](#service-name).
 - `version`, `commit`, `branch` - Used to configure [build_info](#build-info).
 
-Below is an example of initializing autometrics with build_info, as well as the `prometheus` tracker. (Note that you can also do this with environment variables.)
+Below is an example of initializing autometrics with build information, as well as the `prometheus` tracker. (Note that you can also accomplish the same confiugration with environment variables.)
 
 ```python
 from autometrics import autometrics, init

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See [Why Autometrics?](https://github.com/autometrics-dev#why-autometrics) for m
 
 1. Add `autometrics` to your project's dependencies:
     ```shell
-    pip install autometrics # or add to your requirements.txt
+    pip install autometrics
     ```
 
 2. Instrument your functions with the `@autometrics` decorator
@@ -53,15 +53,18 @@ See [Why Autometrics?](https://github.com/autometrics-dev#why-autometrics) for m
     from prometheus_client import generate_latest
     
     # Set up a metrics endpoint for Prometheus to scrape
-    # `generate_latest` returns the latest metrics data in the Prometheus text format
+    #   `generate_latest` returns metrics data in the Prometheus text format
     @app.get("/metrics")
     def metrics():
         return Response(generate_latest())
     ```
 
 4. Run Prometheus locally with the [Autometrics CLI](https://docs.autometrics.dev/local-development#getting-started-with-am) or [configure it manually](https://github.com/autometrics-dev#5-configuring-prometheus) to scrape your metrics endpoint
+    ```sh
+    am start :8080 # or whichever port your app runs on
+    ```
   
-5. (Optional) If you have Grafana, import the [Autometrics dashboards](https://github.com/autometrics-dev/autometrics-shared#dashboards) for an overview and detailed view of the function metrics
+5. (Optional) If you have Grafana, import the [Autometrics dashboards](https://github.com/autometrics-dev/autometrics-shared#dashboards) for an overview and detailed view of all the function metrics you've collected
 
 ## Using autometrics-py
 

--- a/README.md
+++ b/README.md
@@ -61,12 +61,13 @@ See [Why Autometrics?](https://github.com/autometrics-dev#why-autometrics) for m
 
 4. Run Prometheus locally with the [Autometrics CLI](https://docs.autometrics.dev/local-development#getting-started-with-am) or [configure it manually](https://github.com/autometrics-dev#5-configuring-prometheus) to scrape your metrics endpoint
     ```sh
-    am start :8080 # Replace `8080` with the port that your app runs on
+     # Replace `8080` with the port that your app runs on
+     am start :8080 
     ```
   
 5. (Optional) If you have Grafana, import the [Autometrics dashboards](https://github.com/autometrics-dev/autometrics-shared#dashboards) for an overview and detailed view of all the function metrics you've collected
 
-## Using `autometrics-py``
+## Using `autometrics-py`
 
 - You can import the library in your code and use the decorator for any function:
 


### PR DESCRIPTION
The README needed a small refresh, including a more prominent `Quickstart` section.

Additionally, I've included a few copy tweaks, as well as links to the autometrics CLI too (`am`)