### PR TITLE
Add autometrics version to build_info

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Description
+
+> Please give context of this change for reviewers. **What did you change, and why?**
+
+## Checklist
+
+- [ ] Describe what you're doing, to help give context for reviewer(s)
+- [ ] Link to any helpful documentation (Github issues, linear, Slack discussions, etc)
+- [ ] Create test cases
+- [ ] Update changelog
+<!-- Use these for release PRs:
+- [ ] Update package version in `pyprojevt.toml`
+- [ ] Update spec version in `constants.py`
+- [ ] Move changes to a new section in `CHANGELOG.md` -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added support for `record_error_if` and `record_success_if`
 - Added OTLP exporters for OpenTelemetry tracker (#89)
 - Added `repository_url` and `repository_provider` labels to `build_info` (#97)
+- Added `autometrics.version` label to `build_info` (#101)
 
 ### Changed
 

--- a/src/autometrics/constants.py
+++ b/src/autometrics/constants.py
@@ -1,5 +1,7 @@
 """Constants used by autometrics"""
 
+SPEC_VERSION = "1.0.0"
+
 COUNTER_NAME = "function.calls"
 HISTOGRAM_NAME = "function.calls.duration"
 CONCURRENCY_NAME = "function.calls.concurrent"
@@ -8,6 +10,7 @@ BUILD_INFO_NAME = "build_info"
 SERVICE_NAME = "service.name"
 REPOSITORY_URL = "repository.url"
 REPOSITORY_PROVIDER = "repository.provider"
+AUTOMETRICS_VERSION = "autometrics.version"
 
 
 COUNTER_NAME_PROMETHEUS = COUNTER_NAME.replace(".", "_")
@@ -16,6 +19,7 @@ CONCURRENCY_NAME_PROMETHEUS = CONCURRENCY_NAME.replace(".", "_")
 SERVICE_NAME_PROMETHEUS = SERVICE_NAME.replace(".", "_")
 REPOSITORY_URL_PROMETHEUS = REPOSITORY_URL.replace(".", "_")
 REPOSITORY_PROVIDER_PROMETHEUS = REPOSITORY_PROVIDER.replace(".", "_")
+AUTOMETRICS_VERSION_PROMETHEUS = AUTOMETRICS_VERSION.replace(".", "_")
 
 COUNTER_DESCRIPTION = "Autometrics counter for tracking function calls"
 HISTOGRAM_DESCRIPTION = "Autometrics histogram for tracking function call duration"

--- a/src/autometrics/tracker/opentelemetry.py
+++ b/src/autometrics/tracker/opentelemetry.py
@@ -19,6 +19,7 @@ from ..exemplar import get_exemplar
 from .types import Result
 from ..objectives import Objective, ObjectiveLatency
 from ..constants import (
+    AUTOMETRICS_VERSION,
     CONCURRENCY_NAME,
     CONCURRENCY_DESCRIPTION,
     COUNTER_DESCRIPTION,
@@ -33,6 +34,7 @@ from ..constants import (
     OBJECTIVE_NAME,
     OBJECTIVE_PERCENTILE,
     OBJECTIVE_LATENCY_THRESHOLD,
+    SPEC_VERSION,
 )
 from ..settings import get_settings
 
@@ -165,6 +167,7 @@ class OpenTelemetryTracker:
                     SERVICE_NAME: get_settings()["service_name"],
                     REPOSITORY_URL: get_settings()["repository_url"],
                     REPOSITORY_PROVIDER: get_settings()["repository_provider"],
+                    AUTOMETRICS_VERSION: SPEC_VERSION,
                 },
             )
 

--- a/src/autometrics/tracker/prometheus.py
+++ b/src/autometrics/tracker/prometheus.py
@@ -3,6 +3,7 @@ from typing import Optional
 from prometheus_client import Counter, Histogram, Gauge
 
 from ..constants import (
+    AUTOMETRICS_VERSION_PROMETHEUS,
     COUNTER_NAME_PROMETHEUS,
     HISTOGRAM_NAME_PROMETHEUS,
     CONCURRENCY_NAME_PROMETHEUS,
@@ -18,6 +19,7 @@ from ..constants import (
     OBJECTIVE_PERCENTILE_PROMETHEUS,
     OBJECTIVE_LATENCY_THRESHOLD_PROMETHEUS,
     COMMIT_KEY,
+    SPEC_VERSION,
     VERSION_KEY,
     BRANCH_KEY,
 )
@@ -69,6 +71,7 @@ class PrometheusTracker:
             SERVICE_NAME_PROMETHEUS,
             REPOSITORY_URL_PROMETHEUS,
             REPOSITORY_PROVIDER_PROMETHEUS,
+            AUTOMETRICS_VERSION_PROMETHEUS,
         ],
     )
     prom_gauge_concurrency = Gauge(
@@ -156,6 +159,7 @@ class PrometheusTracker:
                 service_name,
                 repository_url,
                 repository_provider,
+                SPEC_VERSION,
             ).set(1)
 
     def start(

--- a/src/autometrics/tracker/test_tracker.py
+++ b/src/autometrics/tracker/test_tracker.py
@@ -54,7 +54,7 @@ def test_init_prometheus_tracker_set_build_info(monkeypatch):
     assert blob is not None
     data = blob.decode("utf-8")
 
-    prom_build_info = f"""build_info{{branch="{branch}",commit="{commit}",repository_provider="github",repository_url="git@github.com:autometrics-dev/autometrics-py.git",service_name="autometrics",version="{version}"}} 1.0"""
+    prom_build_info = f"""build_info{{autometrics_version="1.0.0",branch="{branch}",commit="{commit}",repository_provider="github",repository_url="git@github.com:autometrics-dev/autometrics-py.git",service_name="autometrics",version="{version}"}} 1.0"""
     assert prom_build_info in data
 
     monkeypatch.delenv("AUTOMETRICS_VERSION", raising=False)
@@ -87,7 +87,7 @@ def test_init_otel_tracker_set_build_info(monkeypatch):
     assert blob is not None
     data = blob.decode("utf-8")
 
-    otel_build_info = f"""build_info{{branch="{branch}",commit="{commit}",repository_provider="github",repository_url="git@github.com:autometrics-dev/autometrics-py.git",service_name="autometrics",version="{version}"}} 1.0"""
+    otel_build_info = f"""build_info{{autometrics_version="1.0.0",branch="{branch}",commit="{commit}",repository_provider="github",repository_url="git@github.com:autometrics-dev/autometrics-py.git",service_name="autometrics",version="{version}"}} 1.0"""
     assert otel_build_info in data
 
     monkeypatch.delenv("AUTOMETRICS_VERSION", raising=False)


### PR DESCRIPTION
Add `autometrics.version` label to `build_info` that contains the spec version that autometrics-py is targeting